### PR TITLE
fix(vite-plugin-webmcp): normalize Windows path for include matching

### DIFF
--- a/packages/vite-plugin-webmcp/src/index.ts
+++ b/packages/vite-plugin-webmcp/src/index.ts
@@ -57,7 +57,8 @@ export function vitePluginWebMcp(options: WebMcpPluginOptions = {}): Plugin {
       if (!/\.[jt]sx?$/.test(cleanId)) return null;
 
       // include 匹配检查
-      const relativePath = nodePath.relative(projectRoot, cleanId);
+      // 统一使用正斜杠，避免 Windows 反斜杠导致 glob 匹配失败
+      const relativePath = nodePath.relative(projectRoot, cleanId).replace(/\\/g, '/');
       const isIncluded = include.some(pattern => {
         const regex = new RegExp(
           '^' +


### PR DESCRIPTION
## Summary
- normalize elativePath to use / before include pattern matching
- fix Windows path separator mismatch causing WebMCP schema injection to be skipped

## Root Cause
On Windows, path.relative() returns backslashes (e.g. src\\main.tsx), but include patterns (e.g. src/**/*.tsx) are matched as forward-slash globs.

## Validation
- rebuilt plugin: pnpm build:plugin
- confirmed generated bundle contains __webmcpSchema = assignments