### PR TITLE
fix(vite-plugin-webmcp): normalize Windows path and fix glob ** regex

### DIFF
--- a/packages/vite-plugin-webmcp/src/__tests__/index.test.ts
+++ b/packages/vite-plugin-webmcp/src/__tests__/index.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { transformCode } from 'webmcp-nexus-core';
+
+/**
+ * mock webmcp-nexus-core，避免真实解析 TypeScript 的开销。
+ * 测试仅关注 include 匹配逻辑，transformCode 一律返回已转换。
+ */
+vi.mock('webmcp-nexus-core', () => ({
+  transformCode: vi.fn(() => ({
+    code: '// transformed',
+    transformed: true,
+  })),
+}));
+
+const mockedTransformCode = vi.mocked(transformCode);
+
+import { vitePluginWebMcp } from '../index';
+
+/**
+ * 构造一个最小化的 Vite ResolvedConfig，仅包含插件实际使用的 config.root 和 resolve.alias。
+ */
+function createMockConfig(root: string, alias?: unknown) {
+  return {
+    root,
+    resolve: { alias: alias ?? [] },
+  } as never;
+}
+
+/**
+ * 初始化插件并模拟 configResolved → transform 调用链。
+ * 返回 transform 的调用结果（null 表示被 include 排除，对象表示被处理）。
+ */
+function runTransform(
+  projectRoot: string,
+  fileId: string,
+  options?: Parameters<typeof vitePluginWebMcp>[0],
+  code = 'export const x = 1;',
+) {
+  const plugin = vitePluginWebMcp(options);
+  (plugin as unknown as { configResolved: Function }).configResolved(createMockConfig(projectRoot));
+  const context = { warn: vi.fn() };
+  return (plugin as unknown as { transform: Function }).transform.call(context, code, fileId);
+}
+
+describe('vitePluginWebMcp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // 恢复默认 mock 实现
+    mockedTransformCode.mockReturnValue({ code: '// transformed', transformed: true });
+  });
+
+  describe('include 匹配', () => {
+    const projectRoot = '/project';
+
+    it('默认 include 匹配 src 下的 .ts 文件', () => {
+      const result = runTransform(projectRoot, '/project/src/main.ts');
+      expect(result).not.toBeNull();
+    });
+
+    it('默认 include 匹配 src 下的 .tsx 文件', () => {
+      const result = runTransform(projectRoot, '/project/src/App.tsx');
+      expect(result).not.toBeNull();
+    });
+
+    it('默认 include 匹配 src 子目录下的文件', () => {
+      const result = runTransform(projectRoot, '/project/src/components/Button.tsx');
+      expect(result).not.toBeNull();
+    });
+
+    it('默认 include 排除 src 之外的文件', () => {
+      const result = runTransform(projectRoot, '/project/tests/main.test.ts');
+      expect(result).toBeNull();
+    });
+
+    it('默认 include 排除非 JS/TS 文件', () => {
+      const result = runTransform(projectRoot, '/project/src/style.css');
+      expect(result).toBeNull();
+    });
+
+    it('自定义 include 覆盖默认值', () => {
+      const result = runTransform(projectRoot, '/project/lib/utils.ts', {
+        include: ['lib/**/*.ts'],
+      });
+      expect(result).not.toBeNull();
+    });
+
+    it('自定义 include 排除未匹配的文件', () => {
+      const result = runTransform(projectRoot, '/project/src/main.ts', {
+        include: ['lib/**/*.ts'],
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Windows 路径兼容性', () => {
+    it('处理带 query string 的模块 ID', () => {
+      const result = runTransform('/project', '/project/src/main.ts?v=123');
+      expect(result).not.toBeNull();
+    });
+
+    it('排除项目根目录之外的文件', () => {
+      const result = runTransform('/project', '/other/src/main.ts');
+      expect(result).toBeNull();
+    });
+
+    it('多层嵌套目录的 ** 匹配正确', () => {
+      const result = runTransform('/project', '/project/src/a/b/c/d/deep.ts');
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe('configResolved', () => {
+    it('读取 config.root 作为 projectRoot', () => {
+      const plugin = vitePluginWebMcp();
+      (plugin as unknown as { configResolved: Function }).configResolved(
+        createMockConfig('/my-app'),
+      );
+
+      const context = { warn: vi.fn() };
+      const result = (plugin as unknown as { transform: Function }).transform.call(
+        context,
+        'export const x = 1;',
+        '/my-app/src/index.ts',
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it('合并 vite resolve.alias 和用户 alias', () => {
+      const plugin = vitePluginWebMcp({ alias: { '@custom': '/custom/path' } });
+      (plugin as unknown as { configResolved: Function }).configResolved(
+        createMockConfig('/project', [{ find: '@vite', replacement: '/vite/path' }]),
+      );
+
+      const context = { warn: vi.fn() };
+      const result = (plugin as unknown as { transform: Function }).transform.call(
+        context,
+        'export const x = 1;',
+        '/project/src/main.ts',
+      );
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe('transform 行为', () => {
+    it('非 JS/TS 扩展名直接返回 null', () => {
+      const result = runTransform('/project', '/project/src/style.less');
+      expect(result).toBeNull();
+    });
+
+    it('匹配到的文件调用 transformCode', () => {
+      runTransform('/project', '/project/src/main.ts');
+      expect(mockedTransformCode).toHaveBeenCalledTimes(1);
+      expect(mockedTransformCode).toHaveBeenCalledWith(
+        'export const x = 1;',
+        '/project/src/main.ts',
+        expect.objectContaining({ projectRoot: '/project' }),
+      );
+    });
+
+    it('transformCode 返回 transformed=false 时返回 null', () => {
+      mockedTransformCode.mockReturnValueOnce({ code: '// unchanged', transformed: false });
+
+      const result = runTransform('/project', '/project/src/main.ts');
+      expect(result).toBeNull();
+    });
+
+    it('transformCode 抛错时 warn 并返回 null', () => {
+      mockedTransformCode.mockImplementationOnce(() => {
+        throw new Error('parse failed');
+      });
+
+      const plugin = vitePluginWebMcp();
+      (plugin as unknown as { configResolved: Function }).configResolved(
+        createMockConfig('/project'),
+      );
+
+      const warnSpy = vi.fn();
+      const result = (plugin as unknown as { transform: Function }).transform.call(
+        { warn: warnSpy },
+        'invalid code',
+        '/project/src/main.ts',
+      );
+
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('parse failed'));
+    });
+  });
+});

--- a/packages/vite-plugin-webmcp/src/index.ts
+++ b/packages/vite-plugin-webmcp/src/index.ts
@@ -56,16 +56,17 @@ export function vitePluginWebMcp(options: WebMcpPluginOptions = {}): Plugin {
       const cleanId = id.split('?')[0];
       if (!/\.[jt]sx?$/.test(cleanId)) return null;
 
-      // include 匹配检查
-      // 统一使用正斜杠，避免 Windows 反斜杠导致 glob 匹配失败
+      // include 匹配检查（node:path.relative 在 Windows 上返回反斜杠，而 include 正则仅识别正斜杠）
       const relativePath = nodePath.relative(projectRoot, cleanId).replace(/\\/g, '/');
       const isIncluded = include.some(pattern => {
         const regex = new RegExp(
           '^' +
             pattern
               .replace(/\./g, '\\.')
-              .replace(/\*\*\//g, '(?:.*\\/)?')
-              .replace(/\*/g, '[^/]*') +
+              // 先用占位符暂存 **/，避免后续 * 替换破坏 .* 中的 *
+              .replace(/\*\*\//g, '\x01')
+              .replace(/\*/g, '[^/]*')
+              .replace(/\x01/g, '(?:.*\\/)?') +
             '$',
         );
         return regex.test(relativePath);


### PR DESCRIPTION
## Summary

Based on PR #2 by @nblog (Windows path separator fix), with additional improvements.

## Changes

### 1. Normalize Windows path for include matching (from PR #2)
`nodePath.relative()` returns backslash paths on Windows (e.g. `src\\main.tsx`), but the include patterns use forward-slash globs (`src/**/*.tsx`). This caused all files to be silently skipped on Windows.

**Fix**: Add `.replace(/\\\\/g, '/')` after `nodePath.relative()`.

### 2. Fix glob `**` regex conversion bug (new finding)
The glob-to-regex pipeline had a subtle ordering bug: after `**/` was replaced with `(?:.*\\/)?`, the subsequent `*` → `[^/]*` step also replaced the `*` inside `.*`, corrupting the regex. This limited `**` to matching only a single directory level instead of any depth.

**Fix**: Use a placeholder (`\x01`) to protect `**/` during the `*` replacement step.

**Before**: `src/**/*.ts` → `^src/(?:.[^/]*\\/)?[^/]*\\.ts$` — only matches 1 level  
**After**: `src/**/*.ts` → `^src/(?:.*\\/)?[^/]*\\.ts$` — matches any depth

### 3. Add 16 unit tests
First test file for the vite plugin, covering:
- Default and custom include patterns
- Windows path compatibility (query strings, outside-root exclusion)
- Deep nesting with `**` patterns
- configResolved behavior and alias merging
- transformCode mock interactions and error handling