### PR TITLE
fix(webmcp-core): normalize Windows path separators in module identifiers

### DIFF
--- a/packages/webmcp-core/src/ts-extractor.ts
+++ b/packages/webmcp-core/src/ts-extractor.ts
@@ -422,7 +422,7 @@ function resolveObjectLiteralArg(
   const objLiteral = arg as any; // ObjectLiteralExpression
   const filePath = sourceFile.getFilePath();
   const baseDir = projectRoot ?? process.cwd();
-  const relPath = './' + nodePath.relative(baseDir, filePath).replace(/\.tsx?$/, '');
+  const relPath = './' + nodePath.relative(baseDir, filePath).replace(/\\/g, '/').replace(/\.tsx?$/, '');
 
   for (const prop of objLiteral.getProperties()) {
     // 处理 shorthand property：{ searchInPanel } 等价于 { searchInPanel: searchInPanel }
@@ -616,7 +616,7 @@ function resolveNamespaceImportArg(
   const namespaceName = identifier.getText();
   const baseDir = projectRoot ?? process.cwd();
   const relPath =
-    './' + nodePath.relative(baseDir, targetFile.getFilePath()).replace(/\.tsx?$/, '');
+    './' + nodePath.relative(baseDir, targetFile.getFilePath()).replace(/\\/g, '/').replace(/\.tsx?$/, '');
 
   // 遍历源模块的所有导出声明
   for (const exportedDecl of targetFile.getExportedDeclarations()) {
@@ -729,7 +729,7 @@ function resolveClassComponentArg(
 
   const filePath = sourceFile.getFilePath();
   const baseDir = projectRoot ?? process.cwd();
-  const relPath = './' + nodePath.relative(baseDir, filePath).replace(/\.tsx?$/, '');
+  const relPath = './' + nodePath.relative(baseDir, filePath).replace(/\\/g, '/').replace(/\.tsx?$/, '');
 
   // 遍历 class 成员
   const members = (classDecl as any).getMembers?.() ?? [];


### PR DESCRIPTION
## Summary

Normalize `nodePath.relative()` output in `ts-extractor.ts` to use forward slashes, fixing Windows path separator mismatch in generated module identifiers.

## Problem

`ts-extractor.ts` uses `nodePath.relative()` in 3 places to construct `relPath` values that get embedded into generated code as `sourceFile` metadata strings. On Windows, `nodePath.relative()` returns backslash-separated paths (e.g. `src\\components\\Button`), producing `./src\\components\\Button` as the module identifier — which is incorrect for JavaScript import paths and causes runtime module resolution failures.

## Fix

Add `.replace(/\\\\/g, '/')` after each `nodePath.relative()` call (lines 425, 619, 732) to normalize path separators to forward slashes.

## Verification

- All 71 existing core tests pass
- The fix is a no-op on Unix (no backslashes to replace)
- On Windows, it produces correct forward-slash paths (e.g. `./src/components/Button`)